### PR TITLE
Fix max attribute for repeated select lists

### DIFF
--- a/galaxy/converter.py
+++ b/galaxy/converter.py
@@ -510,7 +510,7 @@ def create_repeat_attribute_list(rep_node, param):
         rep_node.attrib["min"] = "0"
     # for the ITEMLISTs which have LISTITEM children we only
     # need one parameter as it is given as a string
-    if param.default is not None: 
+    if param.default is not None and param.default is not _Null:  
         rep_node.attrib["max"] = "1"
     rep_node.attrib["title"] = get_galaxy_parameter_name(param)
 


### PR DESCRIPTION
Fixes an issue with ITEMLIST parameters in OpenMS. E.g. in `XTandemAdapter` the following parameter

```
<ITEMLIST name="fixed_modifications" type="string" description="Fixed modifications, specified using Unimod (www.unimod.org) terms, e.g. &apos;Carbamidomethyl (C)&apos; or &apos;Oxidation (M)&apos;" required="false" advanced="false" restrictions="15N-oxobutanoic (N-term C),2-dimethylsuccinyl (C), [...]/>
```
will become a repeatable select list - which is fine as long as the max value isn't set: It is necessary to add multiple options. 

I do not know what is meant by the comment above this code section, but since it catches the case where no default parameter is set, it should probably also catch `_Null` from ctdopts since that's the value here. 